### PR TITLE
KeepLive.foregroundNotification为null的情况下五秒内会抛异常

### DIFF
--- a/src/main/java/com/fanjun/keeplive/service/JobHandlerService.java
+++ b/src/main/java/com/fanjun/keeplive/service/JobHandlerService.java
@@ -58,6 +58,11 @@ public final class JobHandlerService extends JobService {
                 intent2.setAction(NotificationClickReceiver.CLICK_NOTIFICATION);
                 Notification notification = NotificationUtils.createNotification(this, KeepLive.foregroundNotification.getTitle(), KeepLive.foregroundNotification.getDescription(), KeepLive.foregroundNotification.getIconRes(), intent2);
                 startForeground(13691, notification);
+            } else {
+                Intent intent2 = new Intent(getApplicationContext(), NotificationClickReceiver.class);
+                intent2.setAction(NotificationClickReceiver.CLICK_NOTIFICATION);
+                Notification notification = NotificationUtils.createNotification(this, "", "", 0, intent2);
+                startForeground(13691, notification);
             }
         }
         //启动本地服务


### PR DESCRIPTION
参考链接:https://blog.csdn.net/sinat_20059415/article/details/80584487